### PR TITLE
[refactor] Session-related models now take a userId as input

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "cookie-parser": "~1.3.4",
     "express": "~4.12.2",
     "morgan": "~1.5.1",
-    "serve-favicon": "~2.2.0"
+    "serve-favicon": "~2.2.0",
+    "socket.io": "^1.3.5"
   },
   "devDependencies": {
     "chai": "^1.9.1",

--- a/server/collections/SessionsCollection.js
+++ b/server/collections/SessionsCollection.js
@@ -13,8 +13,8 @@ exports.SessionsCollection = Backbone.Collection.extend({
   },
 
   // Wrappers for SessionModel methods for convenience
-  addUser: function(sessionId) {
-    return this.get(sessionId).addUser();
+  addUser: function(sessionId, userId) {
+    return this.get(sessionId).addUser(userId);
   },
   changeVote: function(sessionId, userId, voteVal) {
     // Returns [hasChanged, stepCount]
@@ -24,6 +24,7 @@ exports.SessionsCollection = Backbone.Collection.extend({
       // update firebase with sessionid, userid, voteval, and stepCount
       // addEntry(sessionId, userId, voteVal, changeVoteParams[1]);
     }
+    return changeVoteParams;
   },
   getCurrentAverage: function(sessionId) {
     return this.get(sessionId).getCurrentAverage();

--- a/server/collections/VotesCollection.js
+++ b/server/collections/VotesCollection.js
@@ -6,9 +6,7 @@ exports.VotesCollection = Backbone.Collection.extend({
   model: VoteModel,
 
   // Adds a new user and his or her default vote and returns its unique identifier
-  addNewUser: function() {
-    var user = new VoteModel();
-    this.add(user);
-    return user.cid;
+  addNewUser: function(userId) {
+    this.add(new VoteModel({id: userId}));
   }
 });

--- a/server/models/SessionModel.js
+++ b/server/models/SessionModel.js
@@ -17,15 +17,16 @@ exports.SessionModel = Backbone.Model.extend({
 
     this.set('stepCount', 0);
 
-    if (params && params.interval) {
-      this.set('interval', params.interval);
-      this.set('intervalObject', setInterval(this.update.bind(this), this.get('interval')));
-    }
+    params = params || {};
+    params.interval = params.interval || 2000;
+
+    this.set('interval', params.interval);
+    this.set('intervalObject', setInterval(this._update.bind(this), this.get('interval')));
   },
 
   // Adds a new user and returns its id
-  addUser: function() {
-    return this.get('votes').addNewUser();
+  addUser: function(userId) {
+    this.get('votes').addNewUser(userId);
   },
 
   // Changes the voteVal of an existing user
@@ -33,6 +34,10 @@ exports.SessionModel = Backbone.Model.extend({
   // Returns if voteVals are distinct
   changeVote: function(userId, voteVal) {
     var vote = this.get('votes').get(userId);
+    if (!vote) {
+      this.addUser(userId);
+      vote = this.get('votes').get(userId);
+    }
     if (voteVal !== vote.get('voteVal')) {
       this.set('sumVoteVals', this.get('sumVoteVals') + voteVal - vote.get('voteVal'));
       this.set('voteCount', this.get('voteCount') + (voteVal !== null) - (vote.get('voteVal') !== null));
@@ -44,7 +49,7 @@ exports.SessionModel = Backbone.Model.extend({
 
   // Updates historical average data every interval
   // Averages by number of votes
-  update: function() {
+  _update: function() {
     this.set('cumSumVoteVals', this.get('cumSumVoteVals') + this.get('sumVoteVals'));
     this.set('sumVoteCounts', this.get('sumVoteCounts') + this.get('voteCount'));
     this.set('stepCount', this.get('stepCount') + 1);

--- a/test/server/SessionsCollectionSpec.js
+++ b/test/server/SessionsCollectionSpec.js
@@ -6,52 +6,51 @@ var expect = chai.expect;
 var SessionsCollection = require('../../server/collections/SessionsCollection').SessionsCollection;
 
 describe('SessionsCollection', function() {
-  var sessions;
+  var sessions, sessionId, userId;
 
   beforeEach(function() {
     sessions = new SessionsCollection();
+    sessionId = sessions.addNewSession();
+    userId = '0-EbQqhSIEZK8R8KAAAB';
+    sessions.addUser(sessionId, userId);
   });
 
   describe('session', function() {
     it('creates a new session', function() {
-      var sessionId = sessions.addNewSession();
       expect(sessionId).to.be.a('string');
-      // console.log('sessionId: ', sessionId);
-    });
-    it('adds a new user to a session', function() {
-      var sessionId = sessions.addNewSession();
-      var userId = sessions.addUser(sessionId);
-      expect(userId).to.be.a('string');
-      // console.log('userId: ', userId);
     });
     it('changes a user\'s vote', function() {
-      var sessionId = sessions.addNewSession();
-      var userId = sessions.addUser(sessionId);
       assert.notEqual(sessions.getCurrentAverage(sessionId), sessions.getCurrentAverage(sessionId)); // Assert average to be NaN
       sessions.changeVote(sessionId, userId, 2);
       expect(sessions.getCurrentAverage(sessionId)).to.equal(2);
     });
     it('calculates a historical average', function() {
-      var sessionId = sessions.addNewSession();
-      var userId = sessions.addUser(sessionId);
       sessions.changeVote(sessionId, userId, 2);
       assert.notEqual(sessions.getHistoricalAverage(sessionId), sessions.getHistoricalAverage(sessionId)); // Assert average to be NaN
-      sessions.get(sessionId).update();
+      sessions.get(sessionId)._update();
       expect(sessions.getHistoricalAverage(sessionId)).to.equal(2);
     });
     it('returns whether and when the vote changed', function() {
-      var sessionId = sessions.addNewSession();
-      var userId = sessions.addUser(sessionId);
-
-      sessions.get(sessionId).update();
-      var changeVoteParams1 = sessions.get(sessionId).changeVote(userId, 2);
-      expect(changeVoteParams1[0]).to.be.true;
+      sessions.get(sessionId)._update();
+      var changeVoteParams1 = sessions.changeVote(sessionId, userId, 2);
+      expect(changeVoteParams1[0]).to.equal(true);
       expect(changeVoteParams1[1]).to.equal(1);
 
-      sessions.get(sessionId).update();
-      var changeVoteParams2 = sessions.get(sessionId).changeVote(userId, 2);
-      expect(changeVoteParams2[0]).to.be.false;
+      sessions.get(sessionId)._update();
+      var changeVoteParams2 = sessions.changeVote(sessionId, userId, 2);
+      expect(changeVoteParams2[0]).to.equal(false);
       expect(changeVoteParams2[1]).to.equal(2);
+    });
+    it('will have no effect if a user is added twice', function() {
+      sessions.changeVote(sessionId, userId, 2);
+      sessions.addUser(sessionId, userId);
+      var changeVoteParams = sessions.changeVote(sessionId, userId, 2);
+      expect(changeVoteParams[0]).to.equal(false);
+    });
+    it('will create a user if the vote of a non-existent user is changed', function() {
+      userId = 'aBP9S-wzDhqJFBwfAAAC';
+      var changeVoteParams = sessions.changeVote(sessionId, userId, 2);
+      expect(changeVoteParams[0]).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
- Should use socket.io's generated socket.id as userId
- Handles adding a user twice
- Handles changing the vote of a non-existent user
