### PR TITLE
[refactor] Sessions now have an associated provider and hostId

### DIFF
--- a/server/collections/SessionsCollection.js
+++ b/server/collections/SessionsCollection.js
@@ -17,8 +17,12 @@ exports.SessionsCollection = Backbone.Collection.extend({
   },
   removeSession: function(sessionId) {
     var session = this.remove(sessionId);
-    if(session && !session.get('debug')) {
-      dbUtils.closeSessionInDb(sessionId);
+    if(session) {
+      dbUtils.closeSessionInDb({
+        provider: session.get('provider'),
+        hostId: session.get('hostId'),
+        sessionId: sessionId
+      });
     }
   },
 

--- a/server/models/SessionModel.js
+++ b/server/models/SessionModel.js
@@ -9,7 +9,11 @@ exports.SessionModel = Backbone.Model.extend({
   initialize: function() {
     this.set('intervalObject', setInterval(this._update.bind(this), this.get('interval')));
 
-    dbUtils.openSessionInDb(this.cid);
+    dbUtils.openSessionInDb({
+      provider: this.get('provider'),
+      hostId: this.get('hostId'),
+      sessionId: this.cid
+    });
   },
 
   // defaults is a function so VotesCollection is reinstantiated every time
@@ -29,8 +33,9 @@ exports.SessionModel = Backbone.Model.extend({
       interval: 2000,
       maxAge: 6*60*60*1000, // maxAge is 6 hours
 
-      // If debugging, do not forward to database
-      debug: false
+      // Used in forwarding changes to firebase
+      provider: null,
+      hostId: null
     };
   },
 
@@ -59,9 +64,15 @@ exports.SessionModel = Backbone.Model.extend({
       this.set('voteCount', this.get('voteCount') + (voteVal !== null) - (vote.get('voteVal') !== null));
       vote.set('voteVal', voteVal);
 
-      if (!this.get('debug')) {
-        dbUtils.addToDb(this.cid, userId, voteVal, this.get('stepCount'));
-      }
+      dbUtils.addToDb({
+          provider: this.get('provider'),
+          hostId: this.get('hostId'),
+          sessionId: this.cid
+        }, {
+          guestId: userId,
+          voteVal: voteVal,
+          timeStep: this.get('stepCount')
+      });
     }
   },
 

--- a/test/server/SessionsCollectionSpec.js
+++ b/test/server/SessionsCollectionSpec.js
@@ -10,7 +10,7 @@ describe('SessionsCollection', function() {
 
   beforeEach(function() {
     sessions = new SessionsCollection();
-    sessionId = sessions.addNewSession({debug: true});
+    sessionId = sessions.addNewSession();
     userId = '0-EbQqhSIEZK8R8KAAAB';
     sessions.addUser(sessionId, userId);
   });


### PR DESCRIPTION
- Debug mode for tests is now replaced by not specifying a hostId / provider
- In firebase, provider has children of hostIds which have children of sessions
